### PR TITLE
Add language size to statistics

### DIFF
--- a/app/src/androidTest/java/io/github/stscoundrel/polylinguist/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/io/github/stscoundrel/polylinguist/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package io.github.stscoundrel.polylinguist
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/androidTest/java/io/github/stscoundrel/polylinguist/data/StatisticsRepositoryTest.kt
+++ b/app/src/androidTest/java/io/github/stscoundrel/polylinguist/data/StatisticsRepositoryTest.kt
@@ -18,11 +18,13 @@ val networkStatistics: List<NetworkStatistic> = listOf(
     NetworkStatistic(
         language = "Java",
         percentage = 66.6,
+        size = 1332,
         color = "#F3F3F3"
     ),
     NetworkStatistic(
         language = "Kotlin",
         percentage = 33.3,
+        size = 666,
         color = "#F4F4F4"
     ),
 )
@@ -59,11 +61,13 @@ class StatisticsRepositoryTest {
                 Statistic(
                     language = "Java",
                     percentage = 66.6,
+                    size = 1332,
                     color = "#F3F3F3"
                 ),
                 Statistic(
                     language = "Kotlin",
                     percentage = 33.3,
+                    size = 666,
                     color = "#F4F4F4"
                 )
             )
@@ -84,12 +88,14 @@ class StatisticsRepositoryTest {
             StatisticEntity(
                 language = "Kotlin",
                 percentage = 63.0,
+                size = 1332,
                 color = "FFFFF",
                 date = date
             ),
             StatisticEntity(
                 language = "Java",
                 percentage = 36.0,
+                size = 666,
                 color = "F4F4F4",
                 date = date
             ),
@@ -118,16 +124,18 @@ class StatisticsRepositoryTest {
                 Statistic(
                     language = "Cobol",
                     color = "00000",
+                    size = 1000,
                     percentage = 50.0,
                 ),
                 Statistic(
                     language = "Fortran",
                     color = "FFFFFF",
+                    size = 1000,
                     percentage = 50.0,
                 ),
             )
         )
-        val result = repository.save(
+        repository.save(
             statistics
         )
 

--- a/app/src/androidTest/java/io/github/stscoundrel/polylinguist/data/database/StatisticDaoTest.kt
+++ b/app/src/androidTest/java/io/github/stscoundrel/polylinguist/data/database/StatisticDaoTest.kt
@@ -32,6 +32,7 @@ class StatisticDaoTest {
         val statistic1 = StatisticEntity(
             language = "Kotlin",
             percentage = 63.3,
+            size = 1260,
             color = "FFFFF",
             date = LocalDate.of(2024, 1, 1)
 
@@ -40,6 +41,7 @@ class StatisticDaoTest {
         val statistic2 = StatisticEntity(
             language = "Java",
             percentage = 36.7,
+            size = 734,
             color = "F4F4F4",
             date = LocalDate.of(2024, 1, 1)
 
@@ -59,6 +61,7 @@ class StatisticDaoTest {
         val statistic1 = StatisticEntity(
             language = "Kotlin",
             percentage = 63.3,
+            size = 1260,
             color = "FFFFF",
             date = LocalDate.of(2024, 1, 1)
         )
@@ -66,6 +69,7 @@ class StatisticDaoTest {
         val statistic2 = StatisticEntity(
             language = "Java",
             percentage = 36.7,
+            size = 734,
             color = "F4F4F4",
             date = LocalDate.of(2024, 1, 1)
         )
@@ -83,6 +87,7 @@ class StatisticDaoTest {
         val statistic = StatisticEntity(
             language = "Kotlin",
             percentage = 63.3,
+            size = 1260,
             color = "FFFFF",
             date = LocalDate.of(2024, 1, 1)
         )
@@ -109,18 +114,21 @@ class StatisticDaoTest {
             StatisticEntity(
                 language = "Kotlin",
                 percentage = 63.0,
+                size = 1260,
                 color = "FFFFF",
                 date = LocalDate.of(2024, 1, 1)
             ),
             StatisticEntity(
                 language = "Java",
                 percentage = 36.0,
+                size = 720,
                 color = "F4F4F4",
                 date = LocalDate.of(2024, 1, 1)
             ),
             StatisticEntity(
                 language = "PHP",
                 percentage = 1.0,
+                size = 2,
                 color = "F5F5F5",
                 date = LocalDate.of(2011, 1, 1)
             )
@@ -134,7 +142,7 @@ class StatisticDaoTest {
         assertEquals(results2024.size, 2)
         assertEquals(results2011.size, 1)
 
-        assertEquals(listOf("Kotlin", "Java"), results2024.map{it.language})
+        assertEquals(listOf("Kotlin", "Java"), results2024.map { it.language })
         assertEquals("PHP", results2011.first().language)
     }
 
@@ -144,6 +152,7 @@ class StatisticDaoTest {
         val statistic = StatisticEntity(
             language = "Kotlin",
             percentage = 63.3,
+            size = 1260,
             color = "FFFFF",
             date = date
         )

--- a/app/src/main/java/io/github/stscoundrel/polylinguist/data/Statistic.kt
+++ b/app/src/main/java/io/github/stscoundrel/polylinguist/data/Statistic.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 
 data class Statistic(
     val language: String,
+    val size: Int,
     val percentage: Double,
     val color: String,
 )
@@ -18,6 +19,7 @@ data class Statistics(
 fun createStatisticFromNetWorkStatistic(networkStatistic: NetworkStatistic): Statistic {
     return Statistic(
         language = networkStatistic.language,
+        size = networkStatistic.size,
         percentage = networkStatistic.percentage,
         color = networkStatistic.color,
     )
@@ -26,6 +28,7 @@ fun createStatisticFromNetWorkStatistic(networkStatistic: NetworkStatistic): Sta
 fun createStatisticFromEntity(entity: StatisticEntity): Statistic {
     return Statistic(
         language = entity.language,
+        size = entity.size,
         percentage = entity.percentage,
         color = entity.color,
     )
@@ -34,6 +37,7 @@ fun createStatisticFromEntity(entity: StatisticEntity): Statistic {
 fun createEntityFromStatistic(statistic: Statistic, date: LocalDate): StatisticEntity {
     return StatisticEntity(
         language = statistic.language,
+        size = statistic.size,
         percentage = statistic.percentage,
         color = statistic.color,
         date = date,

--- a/app/src/main/java/io/github/stscoundrel/polylinguist/data/database/StatisticEntity.kt
+++ b/app/src/main/java/io/github/stscoundrel/polylinguist/data/database/StatisticEntity.kt
@@ -9,6 +9,7 @@ data class StatisticEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
     val language: String,
+    val size: Int,
     val percentage: Double,
     val color: String,
     val date: LocalDate

--- a/app/src/main/java/io/github/stscoundrel/polylinguist/data/network/NetworkStatistic.kt
+++ b/app/src/main/java/io/github/stscoundrel/polylinguist/data/network/NetworkStatistic.kt
@@ -8,6 +8,9 @@ data class NetworkStatistic(
     @SerialName(value = "Name")
     val language: String,
 
+    @SerialName(value = "Size")
+    val size: Int,
+
     @SerialName(value = "Percentage")
     val percentage: Double,
 

--- a/app/src/test/java/io/github/stscoundrel/polylinguist/data/network/NetworkStatisticsServiceTest.kt
+++ b/app/src/test/java/io/github/stscoundrel/polylinguist/data/network/NetworkStatisticsServiceTest.kt
@@ -19,10 +19,10 @@ class NetworkStatisticsServiceTest {
     fun getCurrentStatisticsTest() = runBlocking {
         val responseList = listOf(
             NetworkStatistic(
-                language="Java", percentage=2.083404634958113, color="#b07219"
+                language="Java", percentage=2.083404634958113, color="#b07219", size=54178,
             ),
             NetworkStatistic(
-                language="Kotlin", percentage=2.755940787285302, color="#A97BFF"
+                language="Kotlin", percentage=2.755940787285302, color="#A97BFF", size=89221,
             ),
         )
 

--- a/app/src/test/java/io/github/stscoundrel/polylinguist/data/network/PolylinguistHTTPServiceTest.kt
+++ b/app/src/test/java/io/github/stscoundrel/polylinguist/data/network/PolylinguistHTTPServiceTest.kt
@@ -18,7 +18,7 @@ class PolylinguistHTTPServiceTest {
     private lateinit var polylinguistAPIService: PolylinguistHTTPService
 
     // Canned JSON response from the actual API.
-    private val jsonPayload = "[{\"Name\":\"TypeScript\",\"Percentage\":39.507047805095645,\"Color\":\"#3178c6\"},{\"Name\":\"JavaScript\",\"Percentage\":23.969843738884155,\"Color\":\"#f1e05a\"},{\"Name\":\"Go\",\"Percentage\":8.973698833473373,\"Color\":\"#00ADD8\"},{\"Name\":\"Rust\",\"Percentage\":5.517572886283362,\"Color\":\"#dea584\"},{\"Name\":\"Python\",\"Percentage\":5.474465045540108,\"Color\":\"#3572A5\"},{\"Name\":\"C#\",\"Percentage\":4.8665714269233655,\"Color\":\"#178600\"},{\"Name\":\"PHP\",\"Percentage\":4.189343787914038,\"Color\":\"#4F5D95\"},{\"Name\":\"Kotlin\",\"Percentage\":2.755940787285302,\"Color\":\"#A97BFF\"},{\"Name\":\"Java\",\"Percentage\":2.083404634958113,\"Color\":\"#b07219\"},{\"Name\":\"Nim\",\"Percentage\":1.2294002395734593,\"Color\":\"#ffc200\"},{\"Name\":\"Scala\",\"Percentage\":0.789438771291947,\"Color\":\"#c22d40\"},{\"Name\":\"C/C++\",\"Percentage\":0.31821354339913593,\"Color\":\"#555555\"},{\"Name\":\"Dart\",\"Percentage\":0.16377903097727128,\"Color\":\"#00B4AB\"},{\"Name\":\"Dockerfile\",\"Percentage\":0.072525769528794,\"Color\":\"#384d54\"},{\"Name\":\"F#\",\"Percentage\":0.06748818956682581,\"Color\":\"#b845fc\"},{\"Name\":\"Shell\",\"Percentage\":0.021265509305102376,\"Color\":\"#89e051\"}]"
+    private val jsonPayload = "[{\"Name\":\"TypeScript\",\"Size\":1027363,\"Percentage\":39.24044057517542,\"Color\":\"#3178c6\"},{\"Name\":\"JavaScript\",\"Size\":623325,\"Percentage\":23.808086938619766,\"Color\":\"#f1e05a\"},{\"Name\":\"Go\",\"Size\":233471,\"Percentage\":8.91749547290177,\"Color\":\"#00ADD8\"},{\"Name\":\"Rust\",\"Size\":143482,\"Percentage\":5.48033839510214,\"Color\":\"#dea584\"},{\"Name\":\"Python\",\"Size\":142361,\"Percentage\":5.437521460985599,\"Color\":\"#3572A5\"},{\"Name\":\"C#\",\"Size\":126553,\"Percentage\":4.833730118867601,\"Color\":\"#178600\"},{\"Name\":\"PHP\",\"Size\":108942,\"Percentage\":4.16107264631952,\"Color\":\"#4F5D95\"},{\"Name\":\"Kotlin\",\"Size\":89221,\"Percentage\":3.4078230854700102,\"Color\":\"#A97BFF\"},{\"Name\":\"Java\",\"Size\":54178,\"Percentage\":2.06934509952359,\"Color\":\"#b07219\"},{\"Name\":\"Nim\",\"Size\":31970,\"Percentage\":1.2211038213254306,\"Color\":\"#ffc200\"},{\"Name\":\"Scala\",\"Size\":20529,\"Percentage\":0.7841113652796297,\"Color\":\"#c22d40\"},{\"Name\":\"C/C++\",\"Size\":8275,\"Percentage\":0.316066128291146,\"Color\":\"#555555\"},{\"Name\":\"Dart\",\"Size\":4259,\"Percentage\":0.1626737934008448,\"Color\":\"#00B4AB\"},{\"Name\":\"Dockerfile\",\"Size\":1886,\"Percentage\":0.07203634053862251,\"Color\":\"#384d54\"},{\"Name\":\"F#\",\"Size\":1755,\"Percentage\":0.06703275590948171,\"Color\":\"#b845fc\"},{\"Name\":\"Shell\",\"Size\":553,\"Percentage\":0.021122002289426435,\"Color\":\"#89e051\"}]"
 
     @Before
     fun setup() {
@@ -56,7 +56,8 @@ class PolylinguistHTTPServiceTest {
         // Sample stat is as expected.
         val expectedStat = NetworkStatistic(
             language = "TypeScript",
-            percentage = 39.507047805095645,
+            percentage = 39.24044057517542,
+            size = 1027363,
             color = "#3178c6",
         )
 


### PR DESCRIPTION
Represents absolute byte size, whereas percentage is relative to other stats of the time.

Closes #7 