### PR TITLE
Add simplistic statistics history

### DIFF
--- a/app/src/androidTest/java/io/github/stscoundrel/polylinguist/data/StatisticsRepositoryTest.kt
+++ b/app/src/androidTest/java/io/github/stscoundrel/polylinguist/data/StatisticsRepositoryTest.kt
@@ -180,6 +180,94 @@ class StatisticsRepositoryTest {
     }
 
     @Test
+    fun getHistoryTest() = runBlocking {
+        val date2012 = LocalDate.of(2012, 1, 1)
+        val date2020 = LocalDate.of(2020, 1, 1)
+        val date2024 = LocalDate.of(2024, 1, 1)
+
+        val initialStatistics = listOf(
+            StatisticFactory.createStatisticEntity(
+                language = "Kotlin",
+                date = date2012
+            ),
+            StatisticFactory.createStatisticEntity(
+                language = "Java",
+                date = date2012
+            ),
+            StatisticFactory.createStatisticEntity(
+                language = "Kotlin",
+                date = date2020
+            ),
+            StatisticFactory.createStatisticEntity(
+                language = "Java",
+                date = date2020
+            ),
+            StatisticFactory.createStatisticEntity(
+                language = "Kotlin",
+                date = date2024
+            ),
+            StatisticFactory.createStatisticEntity(
+                language = "Java",
+                date = date2024
+            ),
+            StatisticFactory.createStatisticEntity(
+                language = "Golang",
+                date = date2024
+            ),
+        )
+
+        statisticDao.upsertAll(initialStatistics)
+
+        val result = repository.getHistory()
+
+        // Statistics for 4 days. 3 from DB, one from initial stats.
+        assertEquals(4, result.size)
+
+        val expected2012 = Statistics(
+            date = date2012,
+            statistics = listOf(
+                StatisticFactory.createStatistic(
+                    language = "Kotlin",
+                ),
+                StatisticFactory.createStatistic(
+                    language = "Java",
+                )
+            )
+        )
+
+        val expected2020 = Statistics(
+            date = date2020,
+            statistics = listOf(
+                StatisticFactory.createStatistic(
+                    language = "Kotlin",
+                ),
+                StatisticFactory.createStatistic(
+                    language = "Java",
+                )
+            )
+        )
+
+        val expected2024 = Statistics(
+            date = date2024,
+            statistics = listOf(
+                StatisticFactory.createStatistic(
+                    language = "Kotlin",
+                ),
+                StatisticFactory.createStatistic(
+                    language = "Java",
+                ),
+                StatisticFactory.createStatistic(
+                    language = "Golang",
+                )
+            )
+        )
+
+        assertEquals(expected2012, result.first())
+        assertEquals(expected2020, result[1])
+        assertEquals(expected2024, result[2])
+    }
+
+    @Test
     fun saveTest() = runBlocking {
         val statistics = Statistics(
             date = LocalDate.of(1989, 7, 30),

--- a/app/src/androidTest/java/io/github/stscoundrel/polylinguist/testdata/InMemoryStatisticsRepository.kt
+++ b/app/src/androidTest/java/io/github/stscoundrel/polylinguist/testdata/InMemoryStatisticsRepository.kt
@@ -11,6 +11,9 @@ class InMemoryStatisticsRepository(
     private val currentStatistics: Statistics,
 ) : StatisticsRepository {
     val statistics: MutableMap<LocalDate, List<Statistic>> = mutableMapOf()
+    override suspend fun getHistory(): List<Statistics> {
+        TODO("Not yet implemented")
+    }
 
     override suspend fun getCurrent(): Statistics {
         delay(1500)

--- a/app/src/main/java/io/github/stscoundrel/polylinguist/data/DefaultStatisticsRepository.kt
+++ b/app/src/main/java/io/github/stscoundrel/polylinguist/data/DefaultStatisticsRepository.kt
@@ -12,6 +12,13 @@ class DefaultStatisticsRepository(
     private val statisticsDao: StatisticDao,
     private val inMemoryStatisticsProvider: InMemoryStatisticsProvider
 ) : StatisticsRepository {
+    override suspend fun getHistory(): List<Statistics> {
+        val initialStatistics = getInitialStats()
+        val dbStatisticsLists = createStatisticsListFromStatisticEntries(statisticsDao.getAll())
+
+        return dbStatisticsLists + initialStatistics
+    }
+
     override suspend fun getCurrent(): Statistics {
         val networkStatistic = networkStatisticsService.getCurrentStatistics()
 

--- a/app/src/main/java/io/github/stscoundrel/polylinguist/data/StatisticMapper.kt
+++ b/app/src/main/java/io/github/stscoundrel/polylinguist/data/StatisticMapper.kt
@@ -4,6 +4,7 @@ import io.github.stscoundrel.polylinguist.data.database.StatisticEntity
 import io.github.stscoundrel.polylinguist.data.inmemory.InMemoryStatistic
 import io.github.stscoundrel.polylinguist.data.network.NetworkStatistic
 import io.github.stscoundrel.polylinguist.domain.Statistic
+import io.github.stscoundrel.polylinguist.domain.Statistics
 import java.time.LocalDate
 
 fun createStatisticFromNetWorkStatistic(networkStatistic: NetworkStatistic): Statistic {
@@ -41,4 +42,23 @@ fun createEntityFromStatistic(statistic: Statistic, date: LocalDate): StatisticE
         color = statistic.color,
         date = date,
     )
+}
+
+fun createStatisticsListFromStatisticEntries(statistics: List<StatisticEntity>): List<Statistics> {
+    val datesMap: MutableMap<LocalDate, MutableList<Statistic>> = mutableMapOf()
+
+    statistics.forEach {
+        if (!datesMap.containsKey(it.date)) {
+            datesMap[it.date] = mutableListOf()
+        }
+
+        datesMap[it.date]?.add(createStatisticFromEntity(it))
+    }
+
+    return datesMap.map {
+        Statistics(
+            date = it.key,
+            statistics = it.value,
+        )
+    }
 }

--- a/app/src/main/java/io/github/stscoundrel/polylinguist/domain/StatisticsRepository.kt
+++ b/app/src/main/java/io/github/stscoundrel/polylinguist/domain/StatisticsRepository.kt
@@ -3,6 +3,7 @@ package io.github.stscoundrel.polylinguist.domain
 import java.time.LocalDate
 
 interface StatisticsRepository {
+    suspend fun getHistory(): List<Statistics>
     suspend fun getCurrent(): Statistics
 
     suspend fun getLatest(): Statistics

--- a/app/src/test/java/io/github/stscoundrel/polylinguist/testdata/InMemoryStatisticsRepository.kt
+++ b/app/src/test/java/io/github/stscoundrel/polylinguist/testdata/InMemoryStatisticsRepository.kt
@@ -10,6 +10,9 @@ class InMemoryStatisticsRepository(
     private val currentStatistics: Statistics,
 ) : StatisticsRepository {
     val statistics: MutableMap<LocalDate, List<Statistic>> = mutableMapOf()
+    override suspend fun getHistory(): List<Statistics> {
+        TODO("Not yet implemented")
+    }
 
     override suspend fun getCurrent(): Statistics {
         return currentStatistics


### PR DESCRIPTION
Currently just fetches all stats under the hood. Should accept start & end date to allow for simple pagination.

Progresses #30 